### PR TITLE
Fix readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,5 +10,8 @@ python:
     - method: pip
       path: .
 
+sphinx:
+  configuration: docs/conf.py
+
 submodules:
   include: all


### PR DESCRIPTION
See:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/