### PR TITLE
[WIP] Link to system ls-qpack, fall back to vcpkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /build
 /dist
 /docs/_build
+/vcpkg_installed
 
 # Environments
 .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["pkgconfig @ git+https://github.com/CL-Jeremy/pkgconfig.git@pkgconf-detection-and-features", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,10 @@
-import os.path
-import sys
+import os
+from glob import glob
+from subprocess import check_call
 
+import pkgconfig
 import setuptools
 from wheel.bdist_wheel import bdist_wheel
-
-extra_compile_args = []
-include_dirs = [
-    os.path.join("vendor", "ls-qpack"),
-    os.path.join("vendor", "ls-qpack", "deps", "xxhash"),
-]
-if sys.platform == "win32":
-    include_dirs.append(os.path.join("vendor", "ls-qpack", "wincompat"))
-else:
-    extra_compile_args = ["-std=c99"]
-
 
 class bdist_wheel_abi3(bdist_wheel):
     def get_tag(self):
@@ -24,21 +15,23 @@ class bdist_wheel_abi3(bdist_wheel):
 
         return python, abi, plat
 
+ext = setuptools.Extension(
+    "pylsqpack._binding",
+    define_macros=[("Py_LIMITED_API", "0x03080000")],
+    py_limited_api=True,
+    extra_compile_args=[],
+    sources=["src/pylsqpack/binding.c"],
+)
+
+if not pkgconfig.installed("lsqpack", ">= 2.6.2"):
+    check_call(["vcpkg", "install"])
+    prefix = glob("vcpkg_installed/*-*")[0]
+    os.environ["PKG_CONFIG"] = os.path.join(prefix, "tools/pkgconf/pkgconf")
+    os.environ["PKG_CONFIG_PATH"] = os.path.join(prefix, "lib/pkgconfig")
+
+pkgconfig.configure_extension(ext, "lsqpack", keep_system=("cflags", "libs"))
 
 setuptools.setup(
-    ext_modules=[
-        setuptools.Extension(
-            "pylsqpack._binding",
-            define_macros=[("Py_LIMITED_API", "0x03080000")],
-            extra_compile_args=extra_compile_args,
-            include_dirs=include_dirs,
-            py_limited_api=True,
-            sources=[
-                "src/pylsqpack/binding.c",
-                "vendor/ls-qpack/lsqpack.c",
-                "vendor/ls-qpack/deps/xxhash/xxhash.c",
-            ],
-        ),
-    ],
+    ext_modules=[ext],
     cmdclass={"bdist_wheel": bdist_wheel_abi3},
 )

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "pylsqpack",
+  "supports": "static",
+  "version-string": "",
+  "dependencies": [
+    "ls-qpack",
+    "pkgconf"
+  ],
+  "builtin-baseline": "f75c836a67777a86a2c1116a28b179827f028b66",
+  "vcpkg-configuration": {
+    "overlay-ports": [ "./vcpkg_ports/pkgconf" ]
+  }
+}

--- a/vcpkg_ports/pkgconf/darwin.patch
+++ b/vcpkg_ports/pkgconf/darwin.patch
@@ -1,0 +1,21 @@
+diff --git a/meson.build b/meson.build
+index 30928a0..302b2ed 100644
+--- a/meson.build
++++ b/meson.build
+@@ -9,6 +9,7 @@ cc = meson.get_compiler('c')
+ 
+ add_project_arguments(
+   '-D_BSD_SOURCE',
++  '-D_DARWIN_C_SOURCE',
+   '-D_DEFAULT_SOURCE',
+   '-D_POSIX_C_SOURCE=200809L',
+   cc.get_supported_arguments(
+@@ -34,7 +35,7 @@ check_functions = [
+ 
+ foreach f : check_functions
+   name = f[0].to_upper().underscorify()
+-  if cc.has_function(f[0], prefix : '#define _BSD_SOURCE\n#define _DEFAULT_SOURCE\n#define _POSIX_C_SOURCE 200809L\n#include <@0@>'.format(f[1])) and cc.has_header_symbol(f[1], f[0], prefix : '#define _BSD_SOURCE\n#define _DEFAULT_SOURCE\n#define _POSIX_C_SOURCE 200809L')
++  if cc.has_function(f[0], prefix : '#define _BSD_SOURCE\n#define _DARWIN_C_SOURCE\n#define _DEFAULT_SOURCE\n#define _POSIX_C_SOURCE 200809L\n#include <@0@>'.format(f[1])) and cc.has_header_symbol(f[1], f[0], prefix : '#define _BSD_SOURCE\n#define _DARWIN_C_SOURCE\n#define _DEFAULT_SOURCE\n#define _POSIX_C_SOURCE 200809L')
+     cdata.set('HAVE_@0@'.format(name), 1)
+     cdata.set('HAVE_DECL_@0@'.format(name), 1)
+   else

--- a/vcpkg_ports/pkgconf/portfile.cmake
+++ b/vcpkg_ports/pkgconf/portfile.cmake
@@ -1,0 +1,82 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO pkgconf/pkgconf
+    REF "pkgconf-${VERSION}"
+    SHA512 53244f372ea21125a1d97c5b89a84299740b55a66165782e807ed23adab3a07408a1547f1f40156e3060359660d07f49846c8b4893beef10ac9440ab7e8611cc
+    HEAD_REF master
+    PATCHES "darwin.patch"
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    NO_PKG_CONFIG
+    OPTIONS -Dtests=disabled
+)
+
+set(systemsuffix "")
+set(architectureprefix "")
+
+set(SYSTEM_LIBDIR "")
+set(PKG_DEFAULT_PATH "")
+set(SYSTEM_INCLUDEDIR "")
+set(PERSONALITY_PATH "personality.d")
+
+
+if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_CROSSCOMPILING AND VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
+    # These defaults are obtained from pkgconf/pkg-config on Ubuntu and OpenSuse
+    # vcpkg cannot do system introspection to obtain/set these values since it would break binary caching.
+    set(SYSTEM_INCLUDEDIR "/usr/include")
+    # System lib dirs will be stripped from -L from the pkg-config output
+    set(SYSTEM_LIBDIR "/lib:/lib/i386-linux-gnu:/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnux32:/lib64:/lib32:/libx32:/usr/lib:/usr/lib/i386-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnux32:/usr/lib64:/usr/lib32:/usr/libx32")
+    set(PKG_DEFAULT_PATH "/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig")
+    set(PERSONALITY_PATH "/usr/share/pkgconfig/personality.d:/etc/pkgconfig/personality.d")
+endif()
+
+if(DEFINED VCPKG_pkgconf_SYSTEM_LIBDIR)
+    set(SYSTEM_LIBDIR "${VCPKG_pkgconf_SYSTEM_LIBDIR}")
+endif()
+if(DEFINED VCPKG_pkgconf_PKG_DEFAULT_PATH)
+    set(PKG_DEFAULT_PATH "${VCPKG_pkgconf_PKG_DEFAULT_PATH}")
+endif()
+if(DEFINED VCPKG_pkgconf_SYSTEM_INCLUDEDIR)
+    set(SYSTEM_INCLUDEDIR "${VCPKG_pkgconf_SYSTEM_INCLUDEDIR}")
+endif()
+if(DEFINED VCPKG_pkgconf_PERSONALITY_PATH)
+    set(PERSONALITY_PATH "${VCPKG_pkgconf_PERSONALITY_PATH}")
+endif()
+
+
+set(pkgconfig_file "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libpkgconf/config.h")
+if(EXISTS "${pkgconfig_file}")
+    file(READ "${pkgconfig_file}" contents)
+    string(REGEX REPLACE "#define PKG_DEFAULT_PATH [^\n]+" "#define PKG_DEFAULT_PATH \"${PKG_DEFAULT_PATH}\"" contents "${contents}")
+    string(REGEX REPLACE "#define SYSTEM_INCLUDEDIR [^\n]+" "#define SYSTEM_INCLUDEDIR \"${SYSTEM_INCLUDEDIR}\"" contents "${contents}")
+    string(REGEX REPLACE "#define SYSTEM_LIBDIR [^\n]+" "#define SYSTEM_LIBDIR \"${SYSTEM_LIBDIR}\"" contents "${contents}")
+    string(REGEX REPLACE "#define PERSONALITY_PATH [^\n]+" "#define PERSONALITY_PATH \"${PERSONALITY_PATH}\"" contents "${contents}")
+    file(WRITE "${pkgconfig_file}" "${contents}")
+endif()
+set(pkgconfig_file "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libpkgconf/config.h")
+if(EXISTS "${pkgconfig_file}")
+    file(READ "${pkgconfig_file}" contents)
+    string(REGEX REPLACE "#define PKG_DEFAULT_PATH [^\n]+" "#define PKG_DEFAULT_PATH \"${PKG_DEFAULT_PATH}\"" contents "${contents}")
+    string(REGEX REPLACE "#define SYSTEM_INCLUDEDIR [^\n]+" "#define SYSTEM_INCLUDEDIR \"${SYSTEM_INCLUDEDIR}\"" contents "${contents}")
+    string(REGEX REPLACE "#define SYSTEM_LIBDIR [^\n]+" "#define SYSTEM_LIBDIR \"${SYSTEM_LIBDIR}\"" contents "${contents}")
+    string(REGEX REPLACE "#define PERSONALITY_PATH [^\n]+" "#define PERSONALITY_PATH \"${PERSONALITY_PATH}\"" contents "${contents}")
+    file(WRITE "${pkgconfig_file}" "${contents}")
+endif()
+
+vcpkg_install_meson()
+vcpkg_fixup_pkgconfig(SKIP_CHECK)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/man")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/pkgconf/libpkgconf/libpkgconf-api.h" "#if defined(PKGCONFIG_IS_STATIC)" "#if 1")
+endif()
+
+vcpkg_copy_tools(TOOL_NAMES pkgconf AUTO_CLEAN)
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/vcpkg_ports/pkgconf/vcpkg.json
+++ b/vcpkg_ports/pkgconf/vcpkg.json
@@ -1,0 +1,17 @@
+
+{
+  "name": "pkgconf",
+  "version": "2.5.1",
+  "port-version": 0,
+  "description": "pkgconf is a program which helps to configure compiler and linker flags for development libraries. It is similar to pkg-config from freedesktop.org.",
+  "homepage": "https://github.com/pkgconf/pkgconf",
+  "license": null,
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}
+


### PR DESCRIPTION
This pull request adds support for `vcpkg` for building wheels for distribution over PyPI, while opportunistically linking to OS-provided packages, all by using `pkgconf` via [matze/pkgconfig](https://github.com/matze/pkgconfig).

The current solution, notably the use of `glob.glob()` for prefix detection, is arguably fragile (would break if someone copied over the `vcpkg_installed` folder with installed packages from another platform). Probably a clean-up step before the build this would suffice, though.

Also: since the maintainer from Fedora renamed the `pkg-config` package configuration file (Oct 31 2023, https://src.fedoraproject.org/rpms/ls-qpack/c/bc56a0c45fff32c32d157c901e6a57cf1aadc9a6.patch) while waiting their patch (Oct 22 2023, https://github.com/litespeedtech/ls-qpack/pull/55) to be merged upstream, this currently won't work on Fedora. Compare the file names:
| | library name | .pc file name |
|--|--|--|
| **Fedora** |`liblsqpack.so` | `ls-qpack.pc` |
| **Upstream** |`libls-qpack.a` | `lsqpack.pc` |

I have no experience in such communication regarding breaking name changes, so I cannot make a decision yet.

Closes: #42

PS: This is still a work in progress and should wait until the ad-hoc patches have been upstreamed, or when better solutions are found and implemented here.