### PR TITLE
Ensure encoder validates all input before starting encoding

### DIFF
--- a/src/pylsqpack/binding.c
+++ b/src/pylsqpack/binding.c
@@ -435,13 +435,9 @@ Encoder_encode(EncoderObject *self, PyObject *args, PyObject *kwargs)
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "KO", kwlist, &stream_id, &list))
         return NULL;
 
+    // Validate all the input headers.
     if (!PyList_Check(list)) {
         PyErr_SetString(PyExc_ValueError, "headers must be a list");
-        return NULL;
-    }
-
-    if (lsqpack_enc_start_header(&self->enc, stream_id, seqno) != 0) {
-        PyErr_SetString(PyExc_RuntimeError, "lsqpack_enc_start_header failed");
         return NULL;
     }
 
@@ -459,10 +455,28 @@ Encoder_encode(EncoderObject *self, PyObject *args, PyObject *kwargs)
         }
         name_len = PyBytes_Size(name);
         value_len = PyBytes_Size(value);
+        if (name_len == 0) {
+            PyErr_SetString(PyExc_ValueError, "the header's name must not be empty");
+            return NULL;
+        }
         if (name_len + value_len > XHDR_BUF_SZ) {
             PyErr_SetString(PyExc_ValueError, "the header's name and value are too long");
             return NULL;
         }
+    }
+
+    // Start the encoding transaction.
+    if (lsqpack_enc_start_header(&self->enc, stream_id, seqno) != 0) {
+        PyErr_SetString(PyExc_RuntimeError, "lsqpack_enc_start_header failed");
+        return NULL;
+    }
+
+    for (Py_ssize_t i = 0; i < PyList_Size(list); ++i) {
+        tuple = PyList_GetItem(list, i);
+        name = PyTuple_GetItem(tuple, 0);
+        value = PyTuple_GetItem(tuple, 1);
+        name_len = PyBytes_Size(name);
+        value_len = PyBytes_Size(value);
 
         // Copy the header name and value into the xhdr buffer.
         memcpy(self->xhdr_buf, PyBytes_AsString(name), name_len);
@@ -477,6 +491,7 @@ Encoder_encode(EncoderObject *self, PyObject *args, PyObject *kwargs)
                                &xhdr,
                                0) != LQES_OK) {
             PyErr_SetString(PyExc_RuntimeError, "lsqpack_enc_encode failed");
+            lsqpack_enc_end_header(&self->enc, self->pfx_buf, PREFIX_MAX_SIZE, NULL);
             return NULL;
         }
         enc_off += enc_len;
@@ -485,7 +500,7 @@ Encoder_encode(EncoderObject *self, PyObject *args, PyObject *kwargs)
 
     pfx_len = lsqpack_enc_end_header(&self->enc, self->pfx_buf, PREFIX_MAX_SIZE, NULL);
     if (pfx_len <= 0) {
-        PyErr_SetString(PyExc_RuntimeError, "lsqpack_enc_start_header failed");
+        PyErr_SetString(PyExc_RuntimeError, "lsqpack_enc_end_header failed");
         return NULL;
     }
     pfx_off = PREFIX_MAX_SIZE - pfx_len;

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -17,6 +17,13 @@ class EncoderTest(TestCase):
             encoder.encode(stream_id, ["hello"])
         self.assertEqual(str(cm.exception), "the header must be a two-tuple")
 
+    def test_encode_name_empty(self):
+        encoder = Encoder()
+        stream_id = 0
+        with self.assertRaises(ValueError) as cm:
+            encoder.encode(stream_id, [(b"", b"bar")])
+        self.assertEqual(str(cm.exception), "the header's name must not be empty")
+
     def test_encode_name_not_bytes(self):
         encoder = Encoder()
         stream_id = 0


### PR DESCRIPTION
An empty header name (name_len == 0) violates RFC 9114 and triggers undefined behavior in header_block_prepare_decode via realloc(ptr, 0), causing the Python process to abort with a double-free.

Three fixes:
- Reject zero-length header names in Encoder_encode() (RFC 9114 §4.2)
- Move lsqpack_enc_start_header() after input validation to prevent encoder state corruption on early return
- Guard header_block_prepare_decode against space == 0 to avoid undefined behavior with realloc

Reported-by: Sreehari P J <sreeharipj07@gmail.com>